### PR TITLE
Cache Spotify tokens per cookie and auto-refresh only anonymous token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/topi314/spotify-tokener
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20250706212322-41fb261d0659
@@ -13,5 +13,6 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/handler.go
+++ b/handler.go
@@ -31,7 +31,7 @@ type server struct {
 }
 
 type spotifyTokenResponse struct {
-	AccessTokenExpirationTimestampMs int64 `json:"accessTokenExpirationTimestampMs,string"`
+	AccessTokenExpirationTimestampMs int64 `json:"accessTokenExpirationTimestampMs"`
 }
 
 func (s *server) handleToken(w http.ResponseWriter, r *http.Request) {

--- a/handler.go
+++ b/handler.go
@@ -161,7 +161,7 @@ func (s *server) getAccessTokenPayload(rCtx context.Context, cookies []*network.
 }
 
 func (s *server) startAnonymousTokenRefresher() {
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 	
 	for range ticker.C {
@@ -173,7 +173,7 @@ func (s *server) startAnonymousTokenRefresher() {
 			continue
 		}
 
-		if time.Until(entry.Expiry) > time.Minute {
+		if time.Until(entry.Expiry) > 100*time.Millisecond {
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -62,6 +62,8 @@ func main() {
 		},
 	}
 
+	s.startTokenRefresher()
+
 	mux.HandleFunc("/api/token", s.handleToken)
 
 	go s.Start()

--- a/main.go
+++ b/main.go
@@ -60,9 +60,10 @@ func main() {
 			Addr:    addr,
 			Handler: mux,
 		},
+		tokenCache: make(map[string]cachedTokenEntry),
 	}
 
-	s.startTokenRefresher()
+	go s.startAnonymousTokenRefresher()
 
 	mux.HandleFunc("/api/token", s.handleToken)
 
@@ -74,11 +75,6 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, os.Kill)
 	<-sig
-}
-
-type server struct {
-	ctx    context.Context
-	server *http.Server
 }
 
 func (s *server) Start() {


### PR DESCRIPTION
This PR updates the Spotify token handling to support per-cookie caching and proper refresh behavior:

- Introduces a token cache keyed by cookie sets (`cookiesKey`) to allow custom login cookies.
- Anonymous tokens (no cookies) are auto-refreshed in the background.
- Account tokens (with cookies) are cached but not automatically refreshed; they are fetched on-demand.
- Preserves previous fallback expiry logic in case the token response is malformed.
- Improves multi-user support by allowing simultaneous caching of different login sessions.
- Minor logging enhancements to indicate which token (key) is being returned or refreshed.

These changes ensure proper token management for both anonymous and logged-in Spotify users while avoiding unnecessary refreshes of account tokens.
